### PR TITLE
Stop raising SystemError when no database name given

### DIFF
--- a/lib/Connection.cpp
+++ b/lib/Connection.cpp
@@ -294,7 +294,7 @@ bool Connection::processHandshake()
       return false;
     }
 
-    if (!(serverCaps & MCP_CONNECT_WITH_DB) && m_database.empty())
+    if ((serverCaps & MCP_CONNECT_WITH_DB) && m_database.empty())
     {
       m_clientCaps &= ~MCP_CONNECT_WITH_DB;
     }

--- a/python/umysql.c
+++ b/python/umysql.c
@@ -857,7 +857,7 @@ PyObject *Connection_connect(Connection *self, PyObject *args)
 
   if (!UMConnection_Connect (self->conn, host, port, username, password, database, acObj ? &autoCommit : NULL, charset))
   {
-    return NULL;
+    return HandleError(self, "connect");
   }
 
   Py_RETURN_NONE;


### PR DESCRIPTION
The test case `tests.testConnectAutoCommitOff` always fails, raising `SystemError: error return without exception set` .

After a bit of debugging, I found there is a little logic error when the database parameter is empty.  I fixed the bug in this pull request, and use `HandleError()` in `Connection_connect()` to raise `umysql.Error` execeptions instead of meaningless `SystemError`.
