### PR TITLE
Decode string for *TEXT columns

### DIFF
--- a/python/umysql.c
+++ b/python/umysql.c
@@ -621,8 +621,11 @@ int API_resultRowValue(void *result, int column, UMTypeInfo *ti, char *value, si
     case MFTYPE_MEDIUM_BLOB:
     case MFTYPE_LONG_BLOB:
     case MFTYPE_BLOB:
-      // Fall through for string encoding
-      valobj = PyString_FromStringAndSize( (const char *) value, cbValue);
+      if (ti->flags & MFFLAG_BINARY_FLAG) {
+        valobj = PyString_FromStringAndSize( (const char *) value, cbValue);
+      } else {
+        valobj = DecodeString (ti, value, cbValue);
+      }
       break;
 
       //PyString family


### PR DESCRIPTION
MySQL uses BLOB type code family to represent both *BLOB and *TEXT column types.  In original code, they are both treated as binary BLOBs, hence ignore the charset and return python strings.  This pull request use the field flags to find out the real type, and decode to unicode if it is a TEXT column.
