### PR TITLE
Fixed raising ValueError for queries that contain the%%.

### DIFF
--- a/python/umysql.c
+++ b/python/umysql.c
@@ -1081,11 +1081,17 @@ PyObject *EscapeQueryArguments(Connection *self, PyObject *inQuery, PyObject *it
 
       iptr ++;
 
-      if (*iptr != 's')
+      if (*iptr != 's' && *iptr != '%')
       {
         Py_DECREF(iterator);
         if (heap) PyObject_Free(obuffer);
         return PyErr_Format (PyExc_ValueError, "Found character %c expected %%", *iptr);
+      }
+
+      if (*iptr == '%')
+      {
+        *(optr++) = *(iptr)++;
+        break;
       }
 
       iptr ++;

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -715,7 +715,22 @@ class TestMySQL(unittest.TestCase):
             self.assertEquals(result, expected)
 
         cnn.close()
-     
+
+    def testPercentEscaping(self):
+        cnn = umysql.Connection()
+        cnn.connect (DB_HOST, 3306, DB_USER, DB_PASSWD, DB_DB)
+        rs = cnn.query("SELECT * FROM `tblautoincint` WHERE `test_id` LIKE '%%10%%'")
+        self.assertEquals([(100, u'piet'), (101, u'piet')], rs.rows)
+
+        rs = cnn.query("SELECT * FROM `tblautoincint` WHERE `test_id` LIKE '%%%s%%'", [10])
+        self.assertEquals([(100, u'piet'), (101, u'piet')], rs.rows)
+
+        # SqlAlchemy query style
+        rs = cnn.query("SELECT * FROM `tblautoincint` WHERE `test_id` LIKE concat(concat('%%', %s), '%%')", [10])
+        self.assertEquals([(100, u'piet'), (101, 'piet')], rs.rows)
+
+        cnn.close()
+
 if __name__ == '__main__':
     from guppy import hpy
     hp = hpy()


### PR DESCRIPTION
Fixed bug with queries like
SELECT \* FROM `test_table` WHERE `some_field` LIKE CONCAT(CONCAT('%%', %s), '%%').
Such queries are generated by SqlAlchemy ORM.
Processing such queries raises an error:
"ValueError: Found character % expected %"

Signed-off-by: Sergey Tsapenko 4031651@gmail.com
