### PR TITLE
convert timestamp values to datetime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/build
+*.pyc

--- a/python/umysql.c
+++ b/python/umysql.c
@@ -569,6 +569,7 @@ int API_resultRowValue(void *result, int column, UMTypeInfo *ti, char *value, si
         break;
       }
 
+    case MFTYPE_TIMESTAMP:
     case MFTYPE_DATETIME:
       {
         int year;
@@ -610,7 +611,6 @@ int API_resultRowValue(void *result, int column, UMTypeInfo *ti, char *value, si
 
       // We ignore these
 
-    case MFTYPE_TIMESTAMP:
     case MFTYPE_TIME:
     case MFTYPE_YEAR:
     case MFTYPE_NEWDATE:


### PR DESCRIPTION
Timestamp types were being ignored and treated as strings; this change
treats timestamps similarly as datetime types (ala pymysql and mysqldb).

Also included in this commit is a fix for the testConnectWithWrongDB
test which was asserting the error status code 1044 which is defined as
ER_DBACCESS_DENIED_ERROR instead of the expected ER_BAD_DB_ERROR 1049.
