### PR TITLE
fix segment fault when query param repr string is large

### DIFF
--- a/lib/Connection.h
+++ b/lib/Connection.h
@@ -108,6 +108,7 @@ private:
   UMConnectionCAPI m_capi;
 
   int m_dbgMethodProgress;
+  int m_dbgFailedRecv;
 
 public:
 

--- a/python/umysql.c
+++ b/python/umysql.c
@@ -1082,7 +1082,11 @@ PyObject *EscapeQueryArguments(Connection *self, PyObject *inQuery, PyObject *it
       if (PyUnicode_Check(arg))
         cbOutQuery += (PyUnicode_GET_SIZE(arg) * 6);
       else
-        cbOutQuery += 64;
+      {
+        int len = PyString_GET_SIZE(PyObject_Str(arg));
+        if (len < 64) len = 64;
+        cbOutQuery += len;
+      }
 
     Py_DECREF(arg);
   }

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -827,6 +827,15 @@ class TestMySQL(unittest.TestCase):
         self.assertEquals([values1, values2, values3, ], rs.rows)
         cnn.close()
 
+    def testLongStrReprObjParam(self):
+        cnn = umysql.Connection()
+        cnn.connect (DB_HOST, DB_PORT, DB_USER, DB_PASSWD, DB_DB)
+        obj = range(1000)
+        result = cnn.query("SELECT '%s'", (obj,))
+        self.assertEqual(result.rows[0][0], str(obj))
+        cnn.close()
+
+
 if __name__ == '__main__':
     from guppy import hpy
     hp = hpy()


### PR DESCRIPTION
fix segment fault when query param like

```
connection.query("select '%s'", (range(1000),))
```
