### PR TITLE
Add SSL support

### DIFF
--- a/lib/Connection.h
+++ b/lib/Connection.h
@@ -94,6 +94,10 @@ private:
   std::string m_database;
   bool m_autoCommit;
   MYSQL_CHARSETS m_charset;
+  std::string m_key;
+  std::string m_cert;
+  std::string m_ca;
+  bool m_useSsl;
   void *m_sockInst;
   PacketReader m_reader;
   PacketWriter m_writer;
@@ -115,7 +119,7 @@ public:
 public:
   Connection(UMConnectionCAPI *_capi);
   ~Connection();
-  bool connect(const char *_host, int _port, const char *_username, const char *_password, const char *_database, int *_autoCommit, MYSQL_CHARSETS _charset);
+  bool connect(const char *_host, int _port, const char *_username, const char *_password, const char *_database, int *_autoCommit, MYSQL_CHARSETS _charset, bool _useSsl, const char *_key, const char *_cert, const char *_ca);
   //void handleSocketEvent (SocketEvents _evt);
   void *query(const char *_query, size_t _cbQuery);
   bool getLastError (const char **_ppOutMessage, int *_outErrno, int *_outErrorType);

--- a/lib/capi.cpp
+++ b/lib/capi.cpp
@@ -79,9 +79,9 @@ EXPORT_ATTR void * UMConnection_Query(UMConnection conn, const char *_query, siz
   return ((Connection *)conn)->query(_query, _cbQuery);
 }
 
-EXPORT_ATTR int UMConnection_Connect (UMConnection conn, const char *_host, int _port, const char *_username, const char *_password, const char *_database, int *_autoCommit, int _charset)
+EXPORT_ATTR int UMConnection_Connect (UMConnection conn, const char *_host, int _port, const char *_username, const char *_password, const char *_database, int *_autoCommit, int _charset, int _useSsl, const char *_key, const char *_cert, const char *_ca)
 {
-  return ((Connection *)conn)->connect(_host, _port, _username, _password, _database, _autoCommit, (MYSQL_CHARSETS) _charset) ? 1 : 0;
+  return ((Connection *)conn)->connect(_host, _port, _username, _password, _database, _autoCommit, (MYSQL_CHARSETS) _charset, _useSsl, _key, _cert, _ca) ? 1 : 0;
 }
 
 EXPORT_ATTR int UMConnection_SetTimeout(UMConnection conn, int timeout)

--- a/python/umysql.h
+++ b/python/umysql.h
@@ -101,6 +101,7 @@ typedef struct __UMConnectionCAPI
   void (*resultRowEnd)(void *result);
   void (*destroyResult)(void *result);
   void *(*resultOK)(UINT64 affected, UINT64 insertId, int serverStatus, const char *message, size_t len);
+  int (*sslWrapSocket)(void **sock, const char *key, const char *cert, const char *ca);
 
 
 } UMConnectionCAPI;
@@ -119,7 +120,7 @@ typedef void * UMConnection;
 UMConnection UMConnection_Create(UMConnectionCAPI *_capi);
 void UMConnection_Destroy(UMConnection _conn);
 void *UMConnection_Query(UMConnection conn, const char *_query, size_t _cbQuery);
-int  UMConnection_Connect (UMConnection conn, const char *_host, int _port, const char *_username, const char *_password, const char *_database, int *_autoCommit, int _charset);
+int  UMConnection_Connect (UMConnection conn, const char *_host, int _port, const char *_username, const char *_password, const char *_database, int *_autoCommit, int _charset, int _useSsl, const char *_key, const char *_cert, const char *_ca);
 int UMConnection_GetLastError (UMConnection conn, const char **_ppOutMessage, int *_outErrno, int *_type);
 int UMConnection_GetTxBufferSize (UMConnection conn);
 int UMConnection_GetRxBufferSize (UMConnection conn);

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ module1 = Extension('umysql',
                 define_macros=[('WIN32_LEAN_AND_MEAN', None)])
 					
 setup (name = 'umysql',
-       version = "2.61",
+       version = "2.62",
        description = "Ultra fast MySQL driver for Python",
        ext_modules = [module1],
        author="Jonas Tarnstrom",


### PR DESCRIPTION
Summary: Add SSL support to ultramysql. pymysql's connections.py convinced me that it could be done in a minimally invasive fashion.

Test Plan: Ran a gevent-based script that ran hundreds of queries in a pool of size 8 in parallel, all with SSL (double-checked via Wireshark).
