### PR TITLE
Fixed memory leak for Packet reader & writer

### DIFF
--- a/lib/PacketReader.cpp
+++ b/lib/PacketReader.cpp
@@ -76,7 +76,7 @@ PacketReader::PacketReader (size_t _cbSize)
 
 PacketReader::~PacketReader (void)
 {
-  delete m_buffStart;
+  delete[] m_buffStart;
 }
 
 void PacketReader::skip()

--- a/lib/PacketWriter.cpp
+++ b/lib/PacketWriter.cpp
@@ -75,7 +75,7 @@ PacketWriter::PacketWriter(size_t _cbSize)
 
 PacketWriter::~PacketWriter(void)
 {
-  delete m_buffStart;
+  delete[] m_buffStart;
 }
 
 // Push/increment write cursor


### PR DESCRIPTION
The PacketReader and PacketWriter didn't delete the allocated buffer
properly causing a memory leak.
