### PR TITLE
Close and delete the socket if connect() fails

### DIFF
--- a/lib/Connection.cpp
+++ b/lib/Connection.cpp
@@ -480,6 +480,9 @@ bool Connection::connect(const char *_host, int _port, const char *_username, co
   if (!connectSocket())
   {
     m_dbgMethodProgress --;
+    m_capi.closeSocket(m_sockInst);
+    m_capi.deleteSocket(m_sockInst);
+    m_sockInst = NULL;
     return false;
   }
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -149,7 +149,7 @@ class TestMySQL(unittest.TestCase):
         try:
             res = cnn.query("select * from kaka");
             assert False, "Expected exception"
-        except(socket.error):    
+        except(RuntimeError):
             pass
         cnn.close()
 
@@ -161,6 +161,7 @@ class TestMySQL(unittest.TestCase):
             assert False, "Expected exception"
         except(socket.error):
             pass
+        self.assertFalse(cnn.is_connected())
         cnn.close()
 
     def testConnectDNSFails(self):


### PR DESCRIPTION
After a failed `connect()`, `is_connected()` oddly returns `True`, and a `query()` will attempt to write to the socket, even though that's hardly going to work at that point.

Attempting a second `connect()` raises `umysql.Error(0, "Socket already connected")`, but after _that_, `is_connected()` returns `False` again, and we're back where we started.

I'm basically a blind monkey banging away at the C++ typewriter here, but my best guess was to close and delete the socket when `connect()` fails. It doesn't seem to have caused a global thermonuclear war. Yet.
