### PR TITLE
PyPy support

### DIFF
--- a/README
+++ b/README
@@ -1,10 +1,12 @@
+:: WARNING ::
+This driver is no longer supported or recommended. See https://github.com/zodb/relstorage/issues/264
+
 :: Description ::
-A fast MySQL driver written in pure C/C++ for Python. 
+A fast MySQL driver written in pure C/C++ for Python.
 Compatible with gevent through monkey patching
 
 :: Requirements ::
-Requires Python (http://www.python.org) 
+Requires Python (http://www.python.org)
 
 :: Installation ::
 python setup.py build install
-

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,8 @@ License :: OSI Approved :: BSD License
 Programming Language :: Python
 Topic :: Database
 Topic :: Software Development :: Libraries :: Python Modules
+Programming Language :: Python :: Implementation :: CPython
+Programming Language :: Python :: Implementation :: PyPy
 """.splitlines()))
 
 """
@@ -75,13 +77,13 @@ try:
 	shutil.rmtree("./build")
 except(OSError):
 	pass
-"""    
-    
+"""
+
 libs = []
 
 if sys.platform != "win32":
     libs.append("stdc++")
-    
+
 if sys.platform == "win32":
     libs.append("ws2_32")
 
@@ -92,16 +94,16 @@ module1 = Extension('umysql',
                 library_dirs = [],
                 libraries=libs,
                 define_macros=[('WIN32_LEAN_AND_MEAN', None)])
-					
+
 setup (name = 'umysql',
-       version = "2.61",
+       version = "2.62.dev0",
        description = "Ultra fast MySQL driver for Python",
        ext_modules = [module1],
        author="Jonas Tarnstrom",
        author_email="jonas.tarnstrom@esn.me",
        download_url="http://github.com/esnme/ultramysql",
        license="BSD License",
-       platforms=['any'],	   
+       platforms=['any'],
 	   url="http://www.esn.me",
        classifiers=CLASSIFIERS,
-	   )       
+	   )


### PR DESCRIPTION
Replaces `PyObject_Malloc/Free` with their `PyMem` counterparts; PyPy does not support the `PyObject` variants. Arguably, based on [the documents for PyMalloc](https://docs.python.org/2.3/whatsnew/section-pymalloc.html) the PyMem variants are a better fit for this use case anyway (`PyObject_` being intended for "small" allocations).

Disables the use of CP1250 under PyPy because it lacks the `PyUnicode_Encode` function.

There are no new tests failures. (`testConnectWithWrongDB` fails with a 1044 error for me and not 1049 with both the original code under CPython and this code under PyPy).
