### PR TITLE
Use standard unix style file-separator in Manifest.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 include README
 include LICENSE
-include python\*.c
-include python\*.h
-include lib\*.cpp
-include lib\*.h
+include python/*.c
+include python/*.h
+include lib/*.cpp
+include lib/*.h


### PR DESCRIPTION
The current backslash separator in Manifest.in does not allow creation of source distributions / rpms on linux. Changing this to the more standard forward slash fixes this issue. ie:

before this change:

```
[steve@localhost ~/src/ultramysql (master)]$ python setup.py sdist
running sdist
running check
reading manifest template 'MANIFEST.in'
warning: no files found matching 'python\*.c'
warning: no files found matching 'python\*.h'
warning: no files found matching 'lib\*.cpp'
warning: no files found matching 'lib\*.h'
writing manifest file 'MANIFEST'
creating umysql-2.61
...
...
Creating tar archive
removing 'umysql-2.61' (and everything under it)

```

after this change:

```
[steve@localhost ~/src/ultramysql (master)]$ python setup.py sdist
running sdist
running check
reading manifest template 'MANIFEST.in'
writing manifest file 'MANIFEST'
creating umysql-2.61
creating umysql-2.61/lib
creating umysql-2.61/python
making hard links in umysql-2.61...
hard linking LICENSE -> umysql-2.61
hard linking README -> umysql-2.61
hard linking setup.py -> umysql-2.61
hard linking ./lib/Connection.cpp -> umysql-2.61/./lib
hard linking ./lib/PacketReader.cpp -> umysql-2.61/./lib
hard linking ./lib/PacketWriter.cpp -> umysql-2.61/./lib
hard linking ./lib/SHA1.cpp -> umysql-2.61/./lib
hard linking ./lib/capi.cpp -> umysql-2.61/./lib
hard linking ./python/io_cpython.c -> umysql-2.61/./python
hard linking ./python/umysql.c -> umysql-2.61/./python
hard linking lib/Connection.h -> umysql-2.61/lib
hard linking lib/PacketReader.h -> umysql-2.61/lib
hard linking lib/PacketWriter.h -> umysql-2.61/lib
hard linking lib/SHA1.h -> umysql-2.61/lib
hard linking lib/mysqldefs.h -> umysql-2.61/lib
hard linking lib/socketdefs.h -> umysql-2.61/lib
hard linking python/umysql.h -> umysql-2.61/python
Creating tar archive
removing 'umysql-2.61' (and everything under it)
```
