### PR TITLE
Fix spurious 'Socket receive buffer full' errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.pyc
 umysql.egg-info
 umysql.so
+/.project
+/.pydevproject

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /build
 *.pyc
+umysql.egg-info
+umysql.so

--- a/README
+++ b/README
@@ -1,10 +1,12 @@
+:: WARNING ::
+This driver is no longer supported or recommended. See https://github.com/zodb/relstorage/issues/264
+
 :: Description ::
-A fast MySQL driver written in pure C/C++ for Python. 
+A fast MySQL driver written in pure C/C++ for Python.
 Compatible with gevent through monkey patching
 
 :: Requirements ::
-Requires Python (http://www.python.org) 
+Requires Python (http://www.python.org)
 
 :: Installation ::
 python setup.py build install
-

--- a/lib/Connection.cpp
+++ b/lib/Connection.cpp
@@ -68,10 +68,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define snprintf _snprintf
 #endif
 
-//#define PRINTMARK() fprintf(stderr, "%08x:%s:%s MARK(%d)\n", GetTickCount(), __FILE__, __FUNCTION__, __LINE__)		
-#define PRINTMARK() 		
+//#define PRINTMARK() fprintf(stderr, "%08x:%s:%s MARK(%d)\n", GetTickCount(), __FILE__, __FUNCTION__, __LINE__)
+#define PRINTMARK()
 
-Connection::Connection (UMConnectionCAPI *_capi) 
+Connection::Connection (UMConnectionCAPI *_capi)
   :	m_reader(MYSQL_RX_BUFFER_SIZE)
   , m_writer(MYSQL_TX_BUFFER_SIZE)
 {
@@ -127,15 +127,16 @@ void Connection::scramble(const char *_scramble1, const char *_scramble2, UINT8 
 
   for (int index = 0; index < 20; index ++)
   {
-    _outToken[index] = final_hash[index] ^ stage1_hash[index]; 
+    _outToken[index] = final_hash[index] ^ stage1_hash[index];
   }
 }
 
 
 bool Connection::readSocket()
 {
+  m_reader.defrag();
   size_t bytesToRecv = m_reader.getEndPtr() - m_reader.getWritePtr();
-  assert (bytesToRecv <= m_reader.getEndPtr() - m_reader.getWritePtr()); 
+  assert (bytesToRecv <= m_reader.getEndPtr() - m_reader.getWritePtr());
 
   if (bytesToRecv == 0)
   {
@@ -207,7 +208,7 @@ bool Connection::close(void)
       m_writer.finalize(0);
 
       if (!sendPacket())
-      {	
+      {
         m_capi.clearException();
       }
     }

--- a/lib/PacketReader.h
+++ b/lib/PacketReader.h
@@ -76,6 +76,7 @@ public:
   PacketReader (size_t cbSize);
   ~PacketReader (void);
   void skip();
+  void defrag();
   void push(size_t _cbData);
   char *getWritePtr();
   char *getStartPtr();

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,8 @@ License :: OSI Approved :: BSD License
 Programming Language :: Python
 Topic :: Database
 Topic :: Software Development :: Libraries :: Python Modules
+Programming Language :: Python :: Implementation :: CPython
+Programming Language :: Python :: Implementation :: PyPy
 """.splitlines()))
 
 """
@@ -75,13 +77,13 @@ try:
 	shutil.rmtree("./build")
 except(OSError):
 	pass
-"""    
-    
+"""
+
 libs = []
 
 if sys.platform != "win32":
     libs.append("stdc++")
-    
+
 if sys.platform == "win32":
     libs.append("ws2_32")
 
@@ -92,16 +94,16 @@ module1 = Extension('umysql',
                 library_dirs = [],
                 libraries=libs,
                 define_macros=[('WIN32_LEAN_AND_MEAN', None)])
-					
+
 setup (name = 'umysql',
-       version = "2.61",
+       version = "2.62.dev0",
        description = "Ultra fast MySQL driver for Python",
        ext_modules = [module1],
        author="Jonas Tarnstrom",
        author_email="jonas.tarnstrom@esn.me",
        download_url="http://github.com/esnme/ultramysql",
        license="BSD License",
-       platforms=['any'],	   
+       platforms=['any'],
 	   url="http://www.esn.me",
        classifiers=CLASSIFIERS,
-	   )       
+	   )


### PR DESCRIPTION
(This may be related to #34.)

In some cases, it was possible for the buffer to be reported as full when in fact it wasn't; it had lots of space at the beginning of the buffer, but the write cursor reached the end. The `skip` method never detected the read and write pointers aligning and so never reset the buffer. This would happen when reading a large result set from the server very quickly; I suspect its occurrence depends on factors like network connection bandwidth and latency as well as the net_buffer_length of the server.

This builds on my previous PR.
