### PR TITLE
DECIMAL columns to float and the query buffer automatically enlarged.

### DIFF
--- a/lib/Connection.cpp
+++ b/lib/Connection.cpp
@@ -134,17 +134,17 @@ void Connection::scramble(const char *_scramble1, const char *_scramble2, UINT8 
 
 bool Connection::readSocket()
 {
+
   size_t bytesToRecv = m_reader.getEndPtr() - m_reader.getWritePtr();
   assert (bytesToRecv <= m_reader.getEndPtr() - m_reader.getWritePtr()); 
 
   if (bytesToRecv == 0)
   {
-    // Socket buffer got full!
-    setError("Socket receive buffer full", 0, UME_OTHER);
-    return false;
+    // Socket buffer got full, so we re resize
+      m_reader.resizeBuffer(m_reader.getSize()*2);
   }
-  else
-    if (bytesToRecv > 65536)
+
+    if (bytesToRecv > 65536 || bytesToRecv == 0)
     {
       bytesToRecv = 65536;
     }

--- a/lib/PacketReader.cpp
+++ b/lib/PacketReader.cpp
@@ -117,6 +117,17 @@ char *PacketReader::getEndPtr()
   return m_buffEnd;
 }
 
+char *PacketReader::resizeBuffer(size_t new_size)
+{
+    char * new_m_buffStart = new char[new_size];
+    memcpy(new_m_buffStart, m_buffStart, getSize());
+    m_writeCursor = new_m_buffStart + (m_writeCursor - m_buffStart);
+    m_buffEnd = new_m_buffStart + new_size;
+    m_readCursor = new_m_buffStart + (m_readCursor - m_buffStart);
+    m_packetEnd = new_m_buffStart + (m_packetEnd - m_buffStart);
+    delete m_buffStart;
+    m_buffStart = new_m_buffStart;
+}
 extern void PrintBuffer(FILE *file, void *_offset, size_t len, int perRow);
 
 

--- a/lib/PacketReader.h
+++ b/lib/PacketReader.h
@@ -81,6 +81,7 @@ public:
   char *getStartPtr();
   char *getEndPtr();
   size_t getSize();
+  char *resizeBuffer(size_t new_size);
   bool havePacket();
 
   UINT8 readByte();

--- a/python/umysql.c
+++ b/python/umysql.c
@@ -571,7 +571,9 @@ int API_resultRowValue(void *result, int column, UMTypeInfo *ti, char *value, si
       //PyFloat
     case MFTYPE_FLOAT:
     case MFTYPE_DOUBLE:
-      {
+    case MFTYPE_DECIMAL:
+    case MFTYPE_NEWDECIMAL:
+    {
         //FIXME: Too fucking slow
         PyObject *sobj = PyString_FromStringAndSize((char *) value, cbValue);
         valobj = PyFloat_FromString (sobj, NULL);
@@ -673,9 +675,7 @@ int API_resultRowValue(void *result, int column, UMTypeInfo *ti, char *value, si
     case MFTYPE_ENUM:
     case MFTYPE_GEOMETRY:
     case MFTYPE_BIT:
-    case MFTYPE_NEWDECIMAL:
     case MFTYPE_SET:
-    case MFTYPE_DECIMAL:
       // Fall through for string encoding
       valobj = PyString_FromStringAndSize( (const char *) value, cbValue);
       break;


### PR DESCRIPTION
1. The DECIMAL MySQL columns were retrieved as strings. I changed that to float, since that's a more appropriate type to retrieve them as.
2. The PacketReader buffer was allocated when the object was created and didn't change it's size. For large queries (SELECT \* FROM large_table) this happened:
   // Socket buffer got full!
   setError("Socket receive buffer full", 0, UME_OTHER);
   return false;
   -- this ended in a python script forced exit.
   I  added char \* PacketReader::resizeBuffer(size_t new_size) to be able to resize the buffer, and in the case of a big query, when the buffer get's filled, the bool Connection::readSocket() method will automatically resize the buffer to twice it's size. A big query can expect more data, so this saves newer allocation times.
